### PR TITLE
Generalize deployer

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -11,6 +11,3 @@ compiler:
     version: 0.8.2
     remappings:
       - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@4.0.0"
-
-hypothesis:
-  max_examples: 1

--- a/contracts/OverlayV1MirinDeployer.sol
+++ b/contracts/OverlayV1MirinDeployer.sol
@@ -20,7 +20,7 @@ contract OverlayV1MirinDeployer {
         bool isPrice0,
         uint256 windowSize,
         uint256 amountIn
-    ) internal returns (OverlayV1MirinMarket marketContract) {
+    ) external returns (OverlayV1MirinMarket marketContract) {
         marketContract = new OverlayV1MirinMarket(
             ovl,
             mirinPool,

--- a/contracts/OverlayV1MirinDeployer.sol
+++ b/contracts/OverlayV1MirinDeployer.sol
@@ -3,60 +3,36 @@ pragma solidity ^0.8.2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-import "./interfaces/IMirinFactory.sol";
-import "./interfaces/IMirinOracle.sol";
-
 import "./OverlayV1MirinMarket.sol";
 
-contract OverlayV1MirinMarketDeployer {
-
-    // ovl erc20 token
-    address public immutable ovl;
-    // mirin pool factory
-    address public immutable mirinFactory;
-
-    constructor(
-        address _ovl,
-        address _mirinFactory
-    ) {
-
-        // immutables
-        ovl = _ovl;
-        mirinFactory = _mirinFactory;
-
-    }
+contract OverlayV1MirinDeployer {
 
     /// @notice Creates a new market contract for given mirin pool address
     function deployMarket(
+        address ovl,
         address mirinPool,
-        bool isPrice0,
         uint256 updatePeriod,
-        uint256 windowSize,
         uint8 leverageMax,
         uint16 marginAdjustment,
         uint144 oiCap,
         uint112 fundingKNumerator,
         uint112 fundingKDenominator,
+        bool isPrice0,
+        uint256 windowSize,
         uint256 amountIn
-    ) external returns (OverlayV1MirinMarket marketContract) {
-
-        require(IMirinFactory(mirinFactory).isPool(mirinPool), "OverlayV1: !MirinPool");
-        require(IMirinOracle(mirinPool).pricePointsLength() > 1, "OverlayV1: !MirinInitialized");
-
+    ) internal returns (OverlayV1MirinMarket marketContract) {
         marketContract = new OverlayV1MirinMarket(
             ovl,
             mirinPool,
-            isPrice0,
             updatePeriod,
-            windowSize,
             leverageMax,
             marginAdjustment,
             oiCap,
             fundingKNumerator,
             fundingKDenominator,
+            isPrice0,
+            windowSize,
             amountIn
         );
-
     }
-
 }

--- a/contracts/OverlayV1MirinDeployer.sol
+++ b/contracts/OverlayV1MirinDeployer.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.2;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-
 import "./OverlayV1MirinMarket.sol";
 
 contract OverlayV1MirinDeployer {

--- a/contracts/OverlayV1MirinFactory.sol
+++ b/contracts/OverlayV1MirinFactory.sol
@@ -1,95 +1,57 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.2;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-
 import "./interfaces/IMirinFactory.sol";
-import "./interfaces/IMirinOracle.sol";
-import "./OverlayV1MirinMarket.sol";
-import "./OverlayV1MirinMarketDeployer.sol";
-import "./OverlayToken.sol";
+import "./market/OverlayV1Factory.sol";
+import "./OverlayV1MirinDeployer.sol";
 
-contract OverlayV1MirinFactory is Ownable {
+contract OverlayV1MirinFactory is OverlayV1Factory {
 
-    uint16 public constant MIN_FEE = 1; // 0.01%
-    uint16 public constant MAX_FEE = 100; // 1.00%
-
-    uint16 public constant MIN_MARGIN_MAINTENANCE = 100; // 1% maintenance
-    uint16 public constant MAX_MARGIN_MAINTENANCE = 6000; // 60% maintenance
-
-    uint16 public constant RESOLUTION = 10**4; // bps
-
-    // ovl erc20 token
-    address public immutable ovl;
-    // mirin pool factory
+    address public immutable deployer;
     address public immutable mirinFactory;
-
-    address public immutable mirinMarketDeployer;
-
-    // global params adjustable by gov
-    // build/unwind trading fee
-    uint16 public fee;
-    // portion of build/unwind fee burnt
-    uint16 public feeBurnRate;
-    // portion of non-burned fees to reward market updaters with (funding + price)
-    uint16 public feeUpdateRewardsRate;
-    // address to send fees to
-    address public feeTo;
-    // maintenance margin requirement
-    uint16 public marginMaintenance;
-    // maintenance margin burn rate on liquidations
-    uint16 public marginBurnRate;
-    // address to send margin to
-    address public marginTo;
-
-    // whether is a market AND is enabled
-    mapping(address => bool) public isMarket;
-    // whether is an already created market: for easy access instead of looping through allMarkets
-    mapping(address => bool) public marketExists;
-    address[] public allMarkets;
 
     constructor(
         address _ovl,
-        address _mirinMarketDeployer,
-        address _mirinFactory,
         uint16 _fee,
         uint16 _feeBurnRate,
         uint16 _feeUpdateRewardsRate,
         address _feeTo,
         uint16 _marginMaintenance,
         uint16 _marginBurnRate,
-        address _marginTo
+        address _marginTo,
+        address _mirinFactory,
+        address _deployer
+    ) OverlayV1Factory(
+        _ovl,
+        _fee,
+        _feeBurnRate,
+        _feeUpdateRewardsRate,
+        _feeTo,
+        _marginMaintenance,
+        _marginBurnRate,
+        _marginTo
     ) {
         // immutables
-        ovl = _ovl;
-        mirinMarketDeployer = _mirinMarketDeployer;
         mirinFactory = _mirinFactory;
-
-        // global params
-        fee = _fee;
-        feeBurnRate = _feeBurnRate;
-        feeUpdateRewardsRate = _feeUpdateRewardsRate;
-        feeTo = _feeTo;
-        marginMaintenance = _marginMaintenance;
-        marginBurnRate = _marginBurnRate;
-        marginTo = _marginTo;
+        deployer = _deployer;
     }
 
     /// @notice Creates a new market contract for given mirin pool address
     function createMarket(
         address mirinPool,
-        bool isPrice0,
         uint256 updatePeriod,
-        uint256 windowSize,
         uint8 leverageMax,
         uint16 marginAdjustment,
         uint144 oiCap,
         uint112 fundingKNumerator,
         uint112 fundingKDenominator,
+        bool isPrice0,
+        uint256 windowSize,
         uint256 amountIn
     ) external onlyOwner returns (OverlayV1MirinMarket marketContract) {
+        require(IMirinFactory(mirinFactory).isPool(mirinPool), "OverlayV1: !MirinPool");
 
-        (bool success, bytes memory result) = mirinMarketDeployer.delegatecall(
+        (bool success, bytes memory result) = deployer.delegatecall(
             abi.encodeWithSignature("deployMarket(address,bool,uint256,uint256,uint8,uint16,uint144,uint112,uint112,uint256)",
             mirinPool,
             isPrice0,
@@ -102,113 +64,8 @@ contract OverlayV1MirinFactory is Ownable {
             fundingKDenominator,
             amountIn
         ));
-
         marketContract = abi.decode(result, (OverlayV1MirinMarket));
 
-        marketExists[address(marketContract)] = true;
-        isMarket[address(marketContract)] = true;
-        allMarkets.push(address(marketContract));
-
-        // Give market contract mint/burn priveleges for OVL
-        OverlayToken(ovl).grantRole(OverlayToken(ovl).MINTER_ROLE(), address(marketContract));
-        OverlayToken(ovl).grantRole(OverlayToken(ovl).BURNER_ROLE(), address(marketContract));
-    }
-
-    /// @notice Disables an existing market contract for a mirin market
-    function disableMarket(address market) external onlyOwner {
-        require(isMarket[market], "OverlayV1: !enabled");
-        isMarket[market] = false;
-
-        // Revoke mint/burn roles for the market
-        OverlayToken(ovl).revokeRole(OverlayToken(ovl).MINTER_ROLE(), market);
-        OverlayToken(ovl).revokeRole(OverlayToken(ovl).BURNER_ROLE(), market);
-    }
-
-    /// @notice Enables an existing market contract for a mirin market
-    function enableMarket(address market) external onlyOwner {
-        require(marketExists[market], "OverlayV1: !exists");
-        require(!isMarket[market], "OverlayV1: !disabled");
-        isMarket[market] = true;
-
-        // Give market contract mint/burn priveleges for OVL token
-        OverlayToken(ovl).grantRole(OverlayToken(ovl).MINTER_ROLE(), market);
-        OverlayToken(ovl).grantRole(OverlayToken(ovl).BURNER_ROLE(), market);
-    }
-
-    /// @notice Calls the update function on a market
-    function updateMarket(address market, address rewardsTo) external {
-        OverlayV1MirinMarket(market).update(rewardsTo);
-    }
-
-    /// @notice Mass calls update functions on all markets
-    function massUpdateMarkets(address rewardsTo) external {
-        for (uint256 i=0; i < allMarkets.length; ++i) {
-            OverlayV1MirinMarket(allMarkets[i]).update(rewardsTo);
-        }
-    }
-
-    /// @notice Allows gov to adjust per market params
-    function adjustPerMarketParams(
-        address market,
-        uint256 updatePeriod,
-        uint8 leverageMax,
-        uint16 marginAdjustment,
-        uint144 oiCap,
-        uint112 fundingKNumerator,
-        uint112 fundingKDenominator
-    ) external onlyOwner {
-        OverlayV1MirinMarket(market).adjustParams(
-            updatePeriod,
-            leverageMax,
-            marginAdjustment,
-            oiCap,
-            fundingKNumerator,
-            fundingKDenominator
-        );
-    }
-
-    /// @notice Allows gov to adjust global params
-    function adjustGlobalParams(
-        uint16 _fee,
-        uint16 _feeBurnRate,
-        uint16 _feeUpdateRewardsRate,
-        address _feeTo,
-        uint16 _marginMaintenance,
-        uint16 _marginBurnRate,
-        address _marginTo
-    ) external onlyOwner {
-        fee = _fee;
-        feeBurnRate = _feeBurnRate;
-        feeUpdateRewardsRate = _feeUpdateRewardsRate;
-        feeTo = _feeTo;
-        marginMaintenance = _marginMaintenance;
-        marginBurnRate = _marginBurnRate;
-        marginTo = _marginTo;
-    }
-
-    function getFeeParams () external view returns (
-        uint16,
-        uint16,
-        uint16,
-        address
-    ) { 
-        return (
-            fee,
-            feeBurnRate,
-            feeUpdateRewardsRate,
-            feeTo
-        );
-    }
-
-    function getMarginParams () external view returns (
-        uint16,
-        uint16,
-        address
-    ) {
-        return (
-            marginMaintenance,
-            marginBurnRate,
-            marginTo
-        );
+        initializeMarket(address(marketContract));
     }
 }

--- a/contracts/OverlayV1MirinFactory.sol
+++ b/contracts/OverlayV1MirinFactory.sol
@@ -12,15 +12,15 @@ contract OverlayV1MirinFactory is OverlayV1Factory {
 
     constructor(
         address _ovl,
+        address _deployer,
+        address _mirinFactory,
         uint16 _fee,
         uint16 _feeBurnRate,
         uint16 _feeUpdateRewardsRate,
         address _feeTo,
         uint16 _marginMaintenance,
         uint16 _marginBurnRate,
-        address _marginTo,
-        address _mirinFactory,
-        address _deployer
+        address _marginTo
     ) OverlayV1Factory(
         _ovl,
         _fee,
@@ -32,8 +32,8 @@ contract OverlayV1MirinFactory is OverlayV1Factory {
         _marginTo
     ) {
         // immutables
-        mirinFactory = _mirinFactory;
         deployer = _deployer;
+        mirinFactory = _mirinFactory;
     }
 
     /// @notice Creates a new market contract for given mirin pool address
@@ -52,16 +52,17 @@ contract OverlayV1MirinFactory is OverlayV1Factory {
         require(IMirinFactory(mirinFactory).isPool(mirinPool), "OverlayV1: !MirinPool");
 
         (bool success, bytes memory result) = deployer.delegatecall(
-            abi.encodeWithSignature("deployMarket(address,bool,uint256,uint256,uint8,uint16,uint144,uint112,uint112,uint256)",
+            abi.encodeWithSignature("deployMarket(address,address,uint256,uint8,uint16,uint144,uint112,uint112,bool,uint256,uint256)",
+            ovl,
             mirinPool,
-            isPrice0,
             updatePeriod,
-            windowSize,
             leverageMax,
             marginAdjustment,
             oiCap,
             fundingKNumerator,
             fundingKDenominator,
+            isPrice0,
+            windowSize,
             amountIn
         ));
         marketContract = abi.decode(result, (OverlayV1MirinMarket));

--- a/contracts/OverlayV1MirinMarket.sol
+++ b/contracts/OverlayV1MirinMarket.sol
@@ -10,8 +10,9 @@ contract OverlayV1MirinMarket is OverlayV1Market {
     using FixedPoint for FixedPoint.uq144x112;
 
     address public immutable mirinPool;
-    bool public immutable isPrice0;
     uint256 public immutable mirinPoolStartIndex;
+    // whether using price0Cumulative or price1Cumulative for TWAP
+    bool public immutable isPrice0;
     // window size for sliding window TWAP calc
     uint256 public immutable windowSize;
     // ideally value of ONE for tokenIn
@@ -20,14 +21,14 @@ contract OverlayV1MirinMarket is OverlayV1Market {
     constructor(
         address _ovl,
         address _mirinPool,
-        bool _isPrice0,
         uint256 _updatePeriod,
-        uint256 _windowSize,
         uint8 _leverageMax,
         uint16 _marginAdjustment,
         uint144 _oiCap,
         uint112 _fundingKNumerator,
         uint112 _fundingKDenominator,
+        bool _isPrice0,
+        uint256 _windowSize,
         uint256 _amountIn
     ) OverlayV1Market(
         "https://metadata.overlay.exchange/v1/mirin/{id}.json",

--- a/contracts/interfaces/IOverlayV1Market.sol
+++ b/contracts/interfaces/IOverlayV1Market.sol
@@ -17,6 +17,7 @@ interface IOverlayV1Market is IERC1155 {
     function oiCap() external view returns (uint256);
     function fundingKNumerator() external view returns (uint256);
     function fundingKDenominator() external view returns (uint256);
+    function adjustParams(uint256, uint8, uint16, uint144, uint112, uint112) external view;
     function updateBlockLast() external view returns (uint256);
     function MAX_FUNDING_COMPOUND() external view returns (uint16);
     function oiLong() external view returns (uint256);

--- a/contracts/market/OverlayV1Factory.sol
+++ b/contracts/market/OverlayV1Factory.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.2;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import "../interfaces/IOverlayV1Market.sol";
+import "../OverlayToken.sol";
+
+contract OverlayV1Factory is Ownable {
+
+    uint16 public constant MIN_FEE = 1; // 0.01%
+    uint16 public constant MAX_FEE = 100; // 1.00%
+
+    uint16 public constant MIN_MARGIN_MAINTENANCE = 100; // 1% maintenance
+    uint16 public constant MAX_MARGIN_MAINTENANCE = 6000; // 60% maintenance
+
+    uint16 public constant RESOLUTION = 10**4; // bps
+
+    // ovl erc20 token
+    address public immutable ovl;
+
+    // global params adjustable by gov
+    // build/unwind trading fee
+    uint16 public fee;
+    // portion of build/unwind fee burnt
+    uint16 public feeBurnRate;
+    // portion of non-burned fees to reward market updaters with (funding + price)
+    uint16 public feeUpdateRewardsRate;
+    // address to send fees to
+    address public feeTo;
+    // maintenance margin requirement
+    uint16 public marginMaintenance;
+    // maintenance margin burn rate on liquidations
+    uint16 public marginBurnRate;
+    // address to send margin to
+    address public marginTo;
+
+    // whether is a market AND is enabled
+    mapping(address => bool) public isMarket;
+    // whether is an already created market: for easy access instead of looping through allMarkets
+    mapping(address => bool) public marketExists;
+    address[] public allMarkets;
+
+    constructor(
+        address _ovl,
+        uint16 _fee,
+        uint16 _feeBurnRate,
+        uint16 _feeUpdateRewardsRate,
+        address _feeTo,
+        uint16 _marginMaintenance,
+        uint16 _marginBurnRate,
+        address _marginTo
+    ) {
+        // immutables
+        ovl = _ovl;
+
+        // global params
+        fee = _fee;
+        feeBurnRate = _feeBurnRate;
+        feeUpdateRewardsRate = _feeUpdateRewardsRate;
+        feeTo = _feeTo;
+        marginMaintenance = _marginMaintenance;
+        marginBurnRate = _marginBurnRate;
+        marginTo = _marginTo;
+    }
+
+    /// @notice Initializes an existing market contract after deployment
+    /// @dev Should be called after contract deployment in specific market factory.createMarket
+    function initializeMarket(address market) internal {
+        marketExists[market] = true;
+        isMarket[market] = true;
+        allMarkets.push(market);
+
+        // Give market contract mint/burn priveleges for OVL
+        OverlayToken(ovl).grantRole(OverlayToken(ovl).MINTER_ROLE(), market);
+        OverlayToken(ovl).grantRole(OverlayToken(ovl).BURNER_ROLE(), market);
+    }
+
+    /// @notice Disables an existing market contract for a mirin market
+    function disableMarket(address market) external onlyOwner {
+        require(isMarket[market], "OverlayV1: !enabled");
+        isMarket[market] = false;
+
+        // Revoke mint/burn roles for the market
+        OverlayToken(ovl).revokeRole(OverlayToken(ovl).MINTER_ROLE(), market);
+        OverlayToken(ovl).revokeRole(OverlayToken(ovl).BURNER_ROLE(), market);
+    }
+
+    /// @notice Enables an existing market contract for a mirin market
+    function enableMarket(address market) external onlyOwner {
+        require(marketExists[market], "OverlayV1: !exists");
+        require(!isMarket[market], "OverlayV1: !disabled");
+        isMarket[market] = true;
+
+        // Give market contract mint/burn priveleges for OVL token
+        OverlayToken(ovl).grantRole(OverlayToken(ovl).MINTER_ROLE(), market);
+        OverlayToken(ovl).grantRole(OverlayToken(ovl).BURNER_ROLE(), market);
+    }
+
+    /// @notice Calls the update function on a market
+    function updateMarket(address market, address rewardsTo) external {
+        IOverlayV1Market(market).update(rewardsTo);
+    }
+
+    /// @notice Mass calls update functions on all markets
+    function massUpdateMarkets(address rewardsTo) external {
+        for (uint256 i=0; i < allMarkets.length; ++i) {
+            IOverlayV1Market(allMarkets[i]).update(rewardsTo);
+        }
+    }
+
+    /// @notice Allows gov to adjust per market params
+    function adjustPerMarketParams(
+        address market,
+        uint256 updatePeriod,
+        uint8 leverageMax,
+        uint16 marginAdjustment,
+        uint144 oiCap,
+        uint112 fundingKNumerator,
+        uint112 fundingKDenominator
+    ) external onlyOwner {
+        IOverlayV1Market(market).adjustParams(
+            updatePeriod,
+            leverageMax,
+            marginAdjustment,
+            oiCap,
+            fundingKNumerator,
+            fundingKDenominator
+        );
+    }
+
+    /// @notice Allows gov to adjust global params
+    function adjustGlobalParams(
+        uint16 _fee,
+        uint16 _feeBurnRate,
+        uint16 _feeUpdateRewardsRate,
+        address _feeTo,
+        uint16 _marginMaintenance,
+        uint16 _marginBurnRate,
+        address _marginTo
+    ) external onlyOwner {
+        fee = _fee;
+        feeBurnRate = _feeBurnRate;
+        feeUpdateRewardsRate = _feeUpdateRewardsRate;
+        feeTo = _feeTo;
+        marginMaintenance = _marginMaintenance;
+        marginBurnRate = _marginBurnRate;
+        marginTo = _marginTo;
+    }
+
+    function getFeeParams() external view returns (
+        uint16,
+        uint16,
+        uint16,
+        address
+    ) {
+        return (
+            fee,
+            feeBurnRate,
+            feeUpdateRewardsRate,
+            feeTo
+        );
+    }
+
+    function getMarginParams() external view returns (
+        uint16,
+        uint16,
+        address
+    ) {
+        return (
+            marginMaintenance,
+            marginBurnRate,
+            marginTo
+        );
+    }
+}

--- a/tests/markets/common/conftest.py
+++ b/tests/markets/common/conftest.py
@@ -81,9 +81,9 @@ def price_points_after(token):
 @pytest.fixture(
     scope="module",
     params=[
-        ("OverlayV1MirinMarketDeployer", [],
+        ("OverlayV1MirinDeployer", [],
          "OverlayV1MirinFactory", [15, 5000, 100, ETH_ADDRESS, 60, 50, ETH_ADDRESS],
-         "OverlayV1MirinMarket", [True, 4, 24, 100, 100, OI_CAP*10**TOKEN_DECIMALS, 1, 8, AMOUNT_IN*10**TOKEN_DECIMALS],
+         "OverlayV1MirinMarket", [4, 100, 100, OI_CAP*10**TOKEN_DECIMALS, 1, 8, True, 24, AMOUNT_IN*10**TOKEN_DECIMALS],
          "MirinFactoryMock", [],
          "IMirinOracle"),
     ])
@@ -98,7 +98,7 @@ def create_factory(token, gov, feed_owner, price_points, price_points_after, req
 
     def create_factory(
         tok=token,
-        ovlmd_type = ovlmd,
+        ovlmd_type=ovlmd,
         ovlf_type=ovlf,
         ovlf_args=ovlf_args,
         ovlm_args=ovlm_args,
@@ -117,8 +117,7 @@ def create_factory(token, gov, feed_owner, price_points, price_points_after, req
         pool_addr = feed.allPools(0)
         pool = ifdp_type(pool_addr)
 
-        deployer = gov.deploy(ovlmd_type, tok, feed)
-
+        deployer = gov.deploy(ovlmd_type)
         factory = gov.deploy(ovlf_type, tok, deployer, feed, *ovlf_args)
         tok.grantRole(tok.ADMIN_ROLE(), factory, {"from": gov})
         factory.createMarket(pool, *ovlm_args, {"from": gov})


### PR DESCRIPTION
- Separates most of the logic from `OverlayV1MirinFactory.sol` into `markets/OverlayV1Factory.sol`
- When offering a new market type, devs simply:
  1. Inherit from `markets/OverlayV1Factory.sol` for the new market type's factory
  2. Implement a feed specific deployer with a `deployMarket()` function that creates new market type's market contract
  3. New market type's `factory.createMarket()` should call deployer's `deployMarket()` function then call OverlayV1Factory's internal `initializeMarket(address)` function to initialize the market appropriately

