### PR TITLE
Change OverlayToken to not require mothership

### DIFF
--- a/contracts/OverlayToken.sol
+++ b/contracts/OverlayToken.sol
@@ -10,9 +10,8 @@ contract OverlayToken is AccessControlEnumerable, ERC20("Overlay", "OVL") {
   bytes32 public constant MINTER_ROLE = keccak256("MINTER");
   bytes32 public constant BURNER_ROLE = keccak256("BURNER");
 
-  constructor(address mothership) {
+  constructor() {
 
-    _setupRole(ADMIN_ROLE, mothership);
     _setupRole(ADMIN_ROLE, msg.sender);
     _setupRole(MINTER_ROLE, msg.sender);
     _setRoleAdmin(MINTER_ROLE, ADMIN_ROLE);

--- a/contracts/mothership/OverlayV1Mothership.sol
+++ b/contracts/mothership/OverlayV1Mothership.sol
@@ -72,7 +72,7 @@ contract OverlayV1Mothership is AccessControlEnumerable {
 
     }
 
-    function setOVL (address _ovl) public {
+    function setOVL (address _ovl) external onlyGovernor {
 
         ovl = _ovl;
 

--- a/tests/markets/collateral/ovl/test_build.py
+++ b/tests/markets/collateral/ovl/test_build.py
@@ -8,6 +8,7 @@ TOKEN_TOTAL_SUPPLY = 8000000
 OI_CAP = 800000e18
 FEE_RESOLUTION = 1e18
 
+
 @given(
     collateral=strategy('uint256', min_value=1e18, max_value=OI_CAP - 1e4),
     leverage=strategy('uint8', min_value=1, max_value=100),
@@ -64,14 +65,14 @@ def test_build_success_zero_impact(
     assert ovl_collateral.balanceOf(bob, pid) == oi_adjusted
 
     # check position attributes for PID
-    (pos_market, 
-    pos_islong, 
-    pos_lev, 
-    _, 
-    pos_oishares, 
-    pos_debt, 
-    pos_cost, 
-    _) = ovl_collateral.positions(pid)
+    (pos_market,
+     pos_islong,
+     pos_lev,
+     _,
+     pos_oishares,
+     pos_debt,
+     pos_cost,
+     _) = ovl_collateral.positions(pid)
 
     assert pos_market == market
     assert pos_islong == is_long
@@ -88,24 +89,26 @@ def test_build_success_zero_impact(
 
 
 def test_build_when_market_not_supported(
-        ovl_collateral,
-        token,
-        mothership,
-        market,
-        notamarket,
-        bob,
-        leverage=1, #doesn't matter
-        is_long=1   #doesn't matter
-    ):
+            ovl_collateral,
+            token,
+            mothership,
+            market,
+            notamarket,
+            bob,
+            leverage=1,  # doesn't matter
+            is_long=1  # doesn't matter
+        ):
 
     EXPECTED_ERROR_MESSAGE = 'OVLV1:!market'
     token.approve(ovl_collateral, 3e18, {"from": bob})
-    trade_amt = MIN_COLLATERAL*2 #just to avoid failing min_collateral check because of fees
+    # just to avoid failing min_collateral check because of fees
+    trade_amt = MIN_COLLATERAL*2
 
     assert mothership.marketActive(market)
     assert not mothership.marketActive(notamarket)
     with brownie.reverts(EXPECTED_ERROR_MESSAGE):
-        ovl_collateral.build(notamarket, trade_amt, leverage, is_long, {'from':bob})
+        ovl_collateral.build(notamarket, trade_amt,
+                             leverage, is_long, {'from': bob})
 
 
 @given(
@@ -114,15 +117,15 @@ def test_build_when_market_not_supported(
     )
 @settings(max_examples=1)
 def test_build_min_collateral(
-        ovl_collateral,
-        token,
-        mothership,
-        market,
-        bob,
-        leverage,
-        is_long
-    ):
-    
+            ovl_collateral,
+            token,
+            mothership,
+            market,
+            bob,
+            leverage,
+            is_long
+        ):
+
     EXPECTED_ERROR_MESSAGE = 'OVLV1:collat<min'
     token.approve(ovl_collateral, 3e18, {"from": bob})
 
@@ -132,50 +135,56 @@ def test_build_min_collateral(
     trade_amt = (MIN_COLLATERAL + fee_offset)
 
     #higher than min collateral passes
-    tx = ovl_collateral.build(market, trade_amt + 1, leverage, is_long, {'from':bob})
+    tx = ovl_collateral.build(market, trade_amt + 1,
+                              leverage, is_long, {'from': bob})
     assert isinstance(tx, brownie.network.transaction.TransactionReceipt)
 
     #lower than min collateral fails
     with brownie.reverts(EXPECTED_ERROR_MESSAGE):
-        ovl_collateral.build(market, trade_amt - 1, leverage, is_long, {'from':bob})
+        ovl_collateral.build(market, trade_amt - 1,
+                             leverage, is_long, {'from': bob})
 
 
 def test_build_max_leverage(
-        ovl_collateral, 
-        token, 
-        market, 
-        bob,
-        collateral=1e18,
-        is_long=1
-    ):
+            ovl_collateral,
+            token,
+            market,
+            bob,
+            collateral=1e18,
+            is_long=1
+        ):
 
     EXPECTED_ERROR_MESSAGE = 'OVLV1:lev>max'
     token.approve(ovl_collateral, collateral, {"from": bob})
-    trade_amt = MIN_COLLATERAL*2 #just to avoid failing min_collateral check because of fees
+    # just to avoid failing min_collateral check because of fees
+    trade_amt = MIN_COLLATERAL*2
 
-    tx = ovl_collateral.build(market, trade_amt, market.leverageMax(), is_long, {'from':bob})
+    tx = ovl_collateral.build(
+        market, trade_amt, market.leverageMax(), is_long, {'from': bob})
     assert isinstance(tx, brownie.network.transaction.TransactionReceipt)
 
     with brownie.reverts(EXPECTED_ERROR_MESSAGE):
-        ovl_collateral.build(market, trade_amt, market.leverageMax() + 1, is_long, {'from':bob})
-
+        ovl_collateral.build(
+            market, trade_amt, market.leverageMax() + 1, is_long, {'from': bob})
 
 
 @given(
-    oi=strategy('uint256', min_value=1.01*OI_CAP*10**TOKEN_DECIMALS, max_value=2**144-1),
+    oi=strategy('uint256', min_value=1.01*OI_CAP*10
+                ** TOKEN_DECIMALS, max_value=2**144-1),
     leverage=strategy('uint8', min_value=1, max_value=100),
     is_long=strategy('bool'))
 def test_build_cap(
-        token, 
-        ovl_collateral, 
-        market, 
-        bob,
-        oi, 
-        leverage, 
-        is_long
-    ):
+            token,
+            ovl_collateral,
+            market,
+            bob,
+            oi,
+            leverage,
+            is_long
+        ):
 
     collateral = int(oi / leverage)
     token.approve(ovl_collateral, collateral, {"from": bob})
     with brownie.reverts("OVLV1:>cap"):
-        ovl_collateral.build(market, collateral, leverage, is_long, {"from": bob})
+        ovl_collateral.build(market, collateral, leverage,
+                             is_long, {"from": bob})

--- a/tests/markets/conftest.py
+++ b/tests/markets/conftest.py
@@ -53,14 +53,18 @@ def fees(accounts):
 def create_token(gov, alice, bob):
     sup = TOKEN_TOTAL_SUPPLY
 
-    def create_token(mothership, supply=sup):
-        tok = gov.deploy(OverlayToken, mothership)
+    def create_token(supply=sup):
+        tok = gov.deploy(OverlayToken)
         tok.mint(gov, supply, {"from": gov})
-        ts = tok.totalSupply()
         tok.transfer(bob, supply, {"from": gov})
         return tok
 
     yield create_token
+
+
+@pytest.fixture(scope="module")
+def token(create_token):
+    yield create_token()
 
 
 def get_uni_feeds(feed_owner):
@@ -154,7 +158,7 @@ def comptroller(gov):
          get_uni_feeds,
         ),
     ])
-def create_mothership(create_token, fees, alice, bob, gov, rewards, feed_owner, request):
+def create_mothership(token, fees, alice, bob, gov, rewards, feed_owner, request):
     ovlms_name, ovlms_args, ovlm_name, ovlm_args, ovlc_name, ovlc_args, get_feed = request.param
 
     chain.mine(timestamp=int(time.time()))
@@ -163,12 +167,12 @@ def create_mothership(create_token, fees, alice, bob, gov, rewards, feed_owner, 
     ovlm = getattr(brownie, ovlm_name)
     ovlc = getattr(brownie, ovlc_name)
 
-    ovlms_args.insert(0, fees)
+    ovlms_args_w_feeto = [fees] + ovlms_args
 
     def create_mothership(
-        c_tok=create_token,
+        tok=token,
         ovlms_type=ovlms,
-        ovlms_args=ovlms_args,
+        ovlms_args=ovlms_args_w_feeto,
         ovlm_type=ovlm,
         ovlm_args=ovlm_args,
         ovlc_type=ovlc,
@@ -181,7 +185,7 @@ def create_mothership(create_token, fees, alice, bob, gov, rewards, feed_owner, 
 
         eth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 
-        tok = c_tok(mothership)
+        tok.grantRole(tok.ADMIN_ROLE(), mothership, {"from": gov})
 
         mothership.setOVL(tok, {'from': gov})
 
@@ -211,11 +215,6 @@ def mothership(create_mothership):
     yield create_mothership()
 
 
-@pytest.fixture(scope="module")
-def token(mothership):
-    yield getattr(interface, 'IOverlayToken')(mothership.ovl())
-
-
 @pytest.fixture(
     scope="module",
     params=['IOverlayV1OVLCollateral'])
@@ -233,6 +232,7 @@ def market(mothership, request):
     market = getattr(interface, request.param)(addr)
     yield market
 
+
 @pytest.fixture(
     scope="module",
     params=["IOverlayV1Market"])
@@ -241,6 +241,7 @@ def notamarket(accounts):
     And we cannot copy or deepcopy contract objects owing to RecursionError: maximum recursion depth exceeded while calling a Python object
     '''
     yield accounts[5]
+
 
 @pytest.fixture(scope="module")
 def uni_test(gov, rewards, accounts):

--- a/tests/token/conftest.py
+++ b/tests/token/conftest.py
@@ -8,26 +8,26 @@ def gov(accounts):
 
 
 @pytest.fixture(scope="module")
-def mothership(accounts):
+def alice(accounts):
     yield accounts[1]
 
 
 @pytest.fixture(scope="module")
-def alice(accounts):
+def bob(accounts):
     yield accounts[2]
 
 
 @pytest.fixture(scope="module")
-def bob(accounts):
+def rando(accounts):
     yield accounts[3]
 
 
 @pytest.fixture(scope="module", params=[8000000])
-def create_token(gov, mothership, alice, bob, request):
+def create_token(gov, alice, bob, request):
     sup = request.param
 
     def create_token(supply=sup):
-        tok = gov.deploy(OverlayToken, mothership)
+        tok = gov.deploy(OverlayToken)
         tok.mint(gov, supply * 10 ** tok.decimals(), {"from": gov})
         tok.transfer(bob, supply * 10 ** tok.decimals(), {"from": gov})
         return tok
@@ -43,8 +43,8 @@ def token(create_token):
 @pytest.fixture(scope="module")
 def create_minter(token, gov, accounts):
     def create_minter(tok=token, governance=gov):
-        tok.grantRole(tok.MINTER_ROLE(), accounts[7], {"from": gov})
-        return accounts[7]
+        tok.grantRole(tok.MINTER_ROLE(), accounts[4], {"from": gov})
+        return accounts[4]
 
     yield create_minter
 
@@ -57,8 +57,8 @@ def minter(create_minter):
 @pytest.fixture(scope="module")
 def create_burner(token, gov, accounts):
     def create_burner(tok=token, governance=gov):
-        tok.grantRole(tok.BURNER_ROLE(), accounts[8], {"from": gov})
-        return accounts[8]
+        tok.grantRole(tok.BURNER_ROLE(), accounts[5], {"from": gov})
+        return accounts[5]
 
     yield create_burner
 
@@ -71,9 +71,8 @@ def burner(create_burner):
 @pytest.fixture(scope="module")
 def create_admin(token, gov, accounts):
     def create_admin(tok=token, governance=gov):
-        tok.grantRole(tok.MINTER_ROLE(), accounts[9], {"from": gov})
-        tok.grantRole(tok.BURNER_ROLE(), accounts[9], {"from": gov})
-        return accounts[9]
+        tok.grantRole(tok.ADMIN_ROLE(), accounts[6], {"from": gov})
+        return accounts[6]
 
     yield create_admin
 
@@ -81,3 +80,18 @@ def create_admin(token, gov, accounts):
 @pytest.fixture(scope="module")
 def admin(create_admin):
     yield create_admin()
+
+
+@pytest.fixture(scope="module")
+def create_market(token, admin, accounts):
+    def create_market(tok=token, adm=admin):
+        tok.grantRole(tok.MINTER_ROLE(), accounts[7], {"from": adm})
+        tok.grantRole(tok.BURNER_ROLE(), accounts[7], {"from": adm})
+        return accounts[7]
+
+    yield create_market
+
+
+@pytest.fixture(scope="module")
+def market(create_market):
+    yield create_market()

--- a/tests/token/test_config.py
+++ b/tests/token/test_config.py
@@ -10,13 +10,19 @@ def test_balances(token, gov, alice, bob, minter, burner, admin):
     assert token.balanceOf(admin) == 0
 
 
-def test_roles(token, gov, minter, burner, admin):
+def test_roles(token, gov, minter, burner, admin, market, rando):
     assert token.hasRole(token.ADMIN_ROLE(), gov) is True
     assert token.hasRole(token.MINTER_ROLE(), minter) is True
     assert token.hasRole(token.BURNER_ROLE(), burner) is True
 
-    assert token.hasRole(token.MINTER_ROLE(), admin) is True
-    assert token.hasRole(token.BURNER_ROLE(), admin) is True
+    assert token.hasRole(token.ADMIN_ROLE(), admin) is True
+
+    assert token.hasRole(token.MINTER_ROLE(), market) is True
+    assert token.hasRole(token.BURNER_ROLE(), market) is True
+
+    assert token.hasRole(token.ADMIN_ROLE(), rando) is False
+    assert token.hasRole(token.MINTER_ROLE(), rando) is False
+    assert token.hasRole(token.BURNER_ROLE(), rando) is False
 
 
 def test_erc20(token):

--- a/tests/token/test_mint_burn.py
+++ b/tests/token/test_mint_burn.py
@@ -28,10 +28,10 @@ def test_burn(token, burner, bob):
     assert token.balanceOf(bob) == before - amount
 
 
-def test_mint_then_burn(token, admin, alice):
+def test_mint_then_burn(token, market, alice):
     before = token.balanceOf(alice)
-    token.mint(alice, 20 * 10 ** token.decimals(), {"from": admin})
+    token.mint(alice, 20 * 10 ** token.decimals(), {"from": market})
     mid = before + 20 * 10 ** token.decimals()
     assert token.balanceOf(alice) == mid
-    token.burn(alice, 15 * 10 ** token.decimals(), {"from": admin})
+    token.burn(alice, 15 * 10 ** token.decimals(), {"from": market})
     assert token.balanceOf(alice) == mid - 15 * 10 ** token.decimals()

--- a/tests/token/test_permissions.py
+++ b/tests/token/test_permissions.py
@@ -1,0 +1,15 @@
+
+def test_admin_grant_mint_role_then_revoke(token, admin, rando):
+    token.grantRole(token.MINTER_ROLE(), rando, {"from": admin})
+    assert token.hasRole(token.MINTER_ROLE(), rando) is True
+
+    token.revokeRole(token.MINTER_ROLE(), rando, {"from": admin})
+    assert token.hasRole(token.MINTER_ROLE(), rando) is False
+
+
+def test_admin_grant_burn_role_then_revoke(token, admin, rando):
+    token.grantRole(token.BURNER_ROLE(), rando, {"from": admin})
+    assert token.hasRole(token.BURNER_ROLE(), rando) is True
+
+    token.revokeRole(token.BURNER_ROLE(), rando, {"from": admin})
+    assert token.hasRole(token.BURNER_ROLE(), rando) is False


### PR DESCRIPTION
Updates `OverlayToken.sol` and test `conftest.py` files so constructor of the token doesn't require mothership. Will require governance to make `OverlayV1Mothership.sol` an admin role after creating the token.